### PR TITLE
feat: support filtering sensitive information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
-Netlify Build plugin epsagon - Instrument JavaScript functions with epsagon.
+Netlify Epsagon Build Plugin - Instrument JavaScript functions with epsagon.
 
-# Install
+## Installation
 
-Please install this plugin from the Netlify app.
+There are two ways to install the plugin in your Netlify site: with the Netlify UI or with file-based installation.
 
-# Configuration
+**UI-based Installation**
 
-The following `inputs` options are available.
+You can install this from your team's [Plugins directory](https://app.netlify.com/plugins) in the Netlify UI.
+
+Read more about [UI-based plugin installation](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation) in our docs.
+
+**File-based Installation**
+
+1. Create a `netlify.toml` in the root of your project. Your file should include the plugins section below:
+
+    ```toml
+    [build]
+      (...)
+
+    [[plugins]]
+      package = "netlify-plugin-epsagon"
+    ```
+
+2. From your project's base directory, use `npm`, `yarn`, or any other Node.js package manager to add this plugin to `devDependencies` in `package.json`.
+
+    ```
+    npm install -D netlify-plugin-epsagon
+    ```
+
+    or
+
+    ```
+    yarn add -D netlify-plugin-epsagon
+    ```
+
+Read more about [file-based plugin installation](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation) in our docs.
+
+## Configuration
+
+In order for this plugin to work a [build environment variable](https://docs.netlify.com/configure-builds/environment-variables/)
+`EPSAGON_TOKEN` needs to be provided.
+
+The following [plugin `inputs`](https://docs.netlify.com/configure-builds/build-plugins/#configure-settings) are available for further configuration:
+
+* `ignoredKeys`: List of sensitive properties and names to be filtered out from traces (defaults to `["token", "authorization"]`)
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,6 @@
 name: 'netlify-plugin-{{name}}'
-inputs: []
-# Example inputs:
-#  - name: example
-#    description: Example description
-#    default: 5
-#    required: false
+inputs:
+ - name: ignoredKeys
+   description: List of sensitive properties and names to be filtered out from traces
+   default: ["token", "authorization"]
+   required: false

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ module.exports = {
         }),
       )
     } catch (error) {
-      build.failBuild('Failed to instrument functions', { error })
+      return build.failBuild('Failed to instrument functions', { error })
     }
     status.show({
       summary: `Successfully instrumented ${functionsList.length} Node.js functions`,

--- a/src/index.js
+++ b/src/index.js
@@ -8,42 +8,62 @@ const rename = util.promisify(fs.rename)
 
 const BUILD_ENVS = ['HEAD', 'BUILD_ID', 'CONTEXT', 'COMMIT_REF', 'SITE_NAME']
 
-const generateTemplate = (content, newFunctionName) => {
+const generateTemplate = (content, newFunctionName, { inputs }) => {
+  // Replace require entry with the original function
   const template = content.replace('REQUIRE_PLACEHOLDER', `${newFunctionName}`)
+
+  // Inject inputs
+  const templateWithInputs = Object.entries(inputs).reduce(
+    (acc, [inputKey, inputValue]) => {
+      const inputToChange = `inputs.${inputKey}`
+      if (typeof inputValue === 'string') {
+        return acc.replace(inputToChange, `'${inputValue}'`)
+      }
+      if (typeof inputValue === 'number') {
+        return acc.replace(inputToChange, `${inputValue}`)
+      }
+      return acc.replace(inputToChange, `${JSON.stringify(inputValue)}`)
+    },
+    template,
+  )
+
+  // Inject env vars from build step
   return BUILD_ENVS.reduce(
     (acc, env) =>
       acc.replace(`process.env.${env}`, `'${process.env[env] || env}'`),
-    template,
+    templateWithInputs,
   )
 }
 
 module.exports = {
-  async onBuild({ utils: { build, status, functions } }) {
+  async onBuild({ utils: { build, status, functions }, inputs }) {
     if (!process.env.EPSAGON_TOKEN) {
       return build.failBuild(
         'Please configure EPSAGON_TOKEN as an environment variable',
       )
     }
 
-    try {
-      const functionsList = await functions.list({ runtime: 'js' })
-      const template = await readFile(`${__dirname}/template.js`, 'utf8')
+    const functionsList = await functions.list({ runtime: 'js' })
+    const template = await readFile(`${__dirname}/template.js`, 'utf8')
 
+    try {
       await Promise.all(
         functionsList.map(async ({ name, mainFile }) => {
           const newFunctionName = `${name}.instrumented`
 
           await rename(mainFile, `${path.dirname(mainFile)}/${newFunctionName}`)
 
-          const wrapper = generateTemplate(template, newFunctionName)
+          const wrapper = generateTemplate(template, newFunctionName, {
+            inputs,
+          })
           await writeFile(mainFile, wrapper)
         }),
       )
-      status.show({
-        summary: `Successfully instrumented ${functionsList.length} Node.js functions`,
-      })
     } catch (error) {
-      build.failBuild('Unknown error', { error })
+      build.failBuild('Failed to instrument functions', { error })
     }
+    status.show({
+      summary: `Successfully instrumented ${functionsList.length} Node.js functions`,
+    })
   },
 }

--- a/src/template.js
+++ b/src/template.js
@@ -7,6 +7,8 @@ epsagon.init({
   token: process.env.EPSAGON_TOKEN || '',
   appName: process.env.SITE_NAME,
   metadataOnly: false,
+  // eslint-disable-next-line no-undef
+  ignoredKeys: inputs.ignoredKeys,
   labels: [
     ['branch', process.env.HEAD],
     ['build-id', process.env.BUILD_ID],


### PR DESCRIPTION
This PR adds support to provide `ignoredKeys` via `inputs` and also sets a default value to it `["token", "authorization"]` - https://github.com/epsagon/epsagon-node/#filter-sensitive-data. Despite not being a compreensive list it avoids tracing values such as `Authorization` headers, or fields/keys named token.

![image](https://user-images.githubusercontent.com/5799039/107083602-cbdb7780-67ed-11eb-9b6d-7b35aa20fd54.png)
